### PR TITLE
Removed minimal version req for File::Basename

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ WriteMakefile(
         'LWP::UserAgent'        => 6.27,
         'LWP::Protocol::https'  => 6.07,
         'JSON::XS'              => 3.04,
-        'File::Basename'        => 2.85,
+        'File::Basename'        => 0,
         'Encode'                => 2.60,
         'IO::Socket::SSL'       => 2.002,
         'File::Path::Tiny'      => 0.8,


### PR DESCRIPTION
Fixes #6

Note that the same goes for `Digest::MD5`, `Encode` & `File::Spec`, as they were added to core way before `5.008008`:
```
$ corelist Digest::MD5 Encode File::Spec

Data for 2019-10-20
Digest::MD5 was first released with perl v5.7.3

Data for 2019-10-20
Encode was first released with perl v5.7.3

Data for 2019-10-20
File::Spec was first released with perl 5.00405
```